### PR TITLE
I refactored the database to propagate errors from `seedLectures` for…

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -15,7 +15,7 @@ export const db = drizzle(sqlite, { schema });
 
 // --- Seeding ---
 // Seed the database with initial lecture data if it's empty.
-function seedLectures(): void {
+export function seedLectures(): void {
 	const lectures = [
 		{
 			id: "math",
@@ -57,9 +57,9 @@ function seedLectures(): void {
 		}
 	} catch (error) {
 		console.error("Error seeding lectures:", error);
+		throw error;
 	}
 }
-seedLectures();
 
 // --- Users ---
 /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,9 +3,18 @@ import { Hono } from "hono";
 import type { Env } from "./types.ts";
 import { serve } from "@hono/node-server";
 import { env } from "std-env";
+import { seedLectures } from "./db/index.ts";
 import { renderer } from "./web/components/Layout.tsx";
 import { sessionMiddleware } from "./web/middleware/session.ts";
 import { appRoutes } from "./web/routes.tsx";
+
+// Seed the database with initial data
+try {
+	seedLectures();
+} catch (error) {
+	console.error("Failed to seed database. Exiting.", error);
+	process.exit(1);
+}
 
 const app = new Hono<Env>();
 


### PR DESCRIPTION
This pull request refactors how the initial lecture data is seeded into the database, moving the responsibility from the database module into the main application entry point. This improves error handling and ensures the application only starts if seeding is successful.

**Database seeding refactor:**

* Changed the `seedLectures` function in `src/db/index.ts` from private to exported, allowing it to be called externally.
* Added a `throw error` statement to propagate seeding errors, rather than just logging them.

**Application startup improvements:**

* Moved the seeding logic from `src/db/index.ts` to `src/main.ts`, so the database is seeded before the server starts. If seeding fails, the application logs the error and exits.… a fail-fast startup.