### PR TITLE
refactor: centralize common utilities

### DIFF
--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -1,0 +1,21 @@
+import { setCookie } from "hono/cookie";
+import type { Context } from "hono";
+import type { CookieOptions } from "hono/utils/cookie";
+
+/**
+ * Set a cookie with security-minded defaults. The options can override defaults.
+ */
+export function setSecureCookie(
+  c: Context,
+  name: string,
+  value: string,
+  options: CookieOptions = {},
+): void {
+  setCookie(c, name, value, {
+    path: "/",
+    httpOnly: true,
+    secure: c.req.url.startsWith("https://"),
+    sameSite: "Lax",
+    ...options,
+  });
+}

--- a/src/utils/id.ts
+++ b/src/utils/id.ts
@@ -1,0 +1,6 @@
+import { nanoid } from "nanoid";
+
+/**
+ * Generate a random ID using nanoid. Accepts optional size to control length.
+ */
+export const generateId = (size?: number): string => (size ? nanoid(size) : nanoid());


### PR DESCRIPTION
## Summary
- add `generateId` helper
- add `setSecureCookie` to standardize cookie options
- reuse session validation logic

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689f27e5f0888330a1c1dad88579cc24